### PR TITLE
Title of home page is aligned left now

### DIFF
--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -98,10 +98,10 @@ const Splash = ({ title, subtitle, video }) => {
       />
       {/* Text */}
       <div className="absolute bottom-0 left-0 py-24 sm:px-16 sm:py-16 max-w-full">
-        <h1 className={`text-center text-6xl  sm:text-6xl sm:text-left font-productsans bold font-extrabold text-transparent bg-clip-text text-white px-5`}>
+        <h1 className={`text-6xl sm:text-6xl text-left font-productsans bold font-extrabold text-transparent bg-clip-text text-white px-5`}>
           {title}
         </h1>
-        <h1 className={`text-center text-5xl sm:text-7xl md:text-8xl sm:text-left font-avenir bold font-extrabold text-transparent bg-clip-text text-white px-4 max-w-full`}>
+        <h1 className={`text-left text-5xl sm:text-7xl md:text-8xl font-avenir bold font-extrabold text-transparent bg-clip-text text-white px-5 max-w-full`}>
           {subtitle}
         </h1>
       </div>


### PR DESCRIPTION
### Fix for title alignment on the home page 
as you asked on the page of the  issue (  https://github.com/SkylineSpartabots/SpartaSite/issues/16#issuecomment-2106340515) , I modified the code and
now in mobile devices like desktop-size the title is aligned to the left 

### Screen
![chrome-capture-2024-4-13](https://github.com/SkylineSpartabots/SpartaSite/assets/79264045/1a512c13-8c60-4e1d-9a76-2a70eaedf7e8)

### Consideration
if you have any question feel free to ask, otherwise merge this PR, I am working on second page today and PR for that will be created tonight
thanks
skyDe

